### PR TITLE
Updated parameters for chat completions

### DIFF
--- a/src/llm_api/_client.py
+++ b/src/llm_api/_client.py
@@ -31,7 +31,16 @@ from ._base_client import (
     AsyncAPIClient,
 )
 
-__all__ = ["Timeout", "Transport", "ProxiesTypes", "RequestOptions", "LlmAPI", "AsyncLlmAPI", "Client", "AsyncClient"]
+__all__ = [
+    "Timeout",
+    "Transport",
+    "ProxiesTypes",
+    "RequestOptions",
+    "LlmAPI",
+    "AsyncLlmAPI",
+    "Client",
+    "AsyncClient",
+]
 
 
 class LlmAPI(SyncAPIClient):
@@ -81,7 +90,7 @@ class LlmAPI(SyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("LLM_API_BASE_URL")
         if base_url is None:
-            base_url = f"https://api.example.com"
+            base_url = f"http://localhost:8000/openai/v1"
 
         super().__init__(
             version=__version__,
@@ -154,10 +163,14 @@ class LlmAPI(SyncAPIClient):
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
         if default_headers is not None and set_default_headers is not None:
-            raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_headers` and `set_default_headers` arguments are mutually exclusive"
+            )
 
         if default_query is not None and set_default_query is not None:
-            raise ValueError("The `default_query` and `set_default_query` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_query` and `set_default_query` arguments are mutually exclusive"
+            )
 
         headers = self._custom_headers
         if default_headers is not None:
@@ -199,10 +212,14 @@ class LlmAPI(SyncAPIClient):
             return _exceptions.BadRequestError(err_msg, response=response, body=body)
 
         if response.status_code == 401:
-            return _exceptions.AuthenticationError(err_msg, response=response, body=body)
+            return _exceptions.AuthenticationError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 403:
-            return _exceptions.PermissionDeniedError(err_msg, response=response, body=body)
+            return _exceptions.PermissionDeniedError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 404:
             return _exceptions.NotFoundError(err_msg, response=response, body=body)
@@ -211,13 +228,17 @@ class LlmAPI(SyncAPIClient):
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
         if response.status_code == 422:
-            return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
+            return _exceptions.UnprocessableEntityError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
-            return _exceptions.InternalServerError(err_msg, response=response, body=body)
+            return _exceptions.InternalServerError(
+                err_msg, response=response, body=body
+            )
         return APIStatusError(err_msg, response=response, body=body)
 
 
@@ -341,10 +362,14 @@ class AsyncLlmAPI(AsyncAPIClient):
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
         if default_headers is not None and set_default_headers is not None:
-            raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_headers` and `set_default_headers` arguments are mutually exclusive"
+            )
 
         if default_query is not None and set_default_query is not None:
-            raise ValueError("The `default_query` and `set_default_query` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_query` and `set_default_query` arguments are mutually exclusive"
+            )
 
         headers = self._custom_headers
         if default_headers is not None:
@@ -386,10 +411,14 @@ class AsyncLlmAPI(AsyncAPIClient):
             return _exceptions.BadRequestError(err_msg, response=response, body=body)
 
         if response.status_code == 401:
-            return _exceptions.AuthenticationError(err_msg, response=response, body=body)
+            return _exceptions.AuthenticationError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 403:
-            return _exceptions.PermissionDeniedError(err_msg, response=response, body=body)
+            return _exceptions.PermissionDeniedError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 404:
             return _exceptions.NotFoundError(err_msg, response=response, body=body)
@@ -398,13 +427,17 @@ class AsyncLlmAPI(AsyncAPIClient):
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
         if response.status_code == 422:
-            return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
+            return _exceptions.UnprocessableEntityError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
-            return _exceptions.InternalServerError(err_msg, response=response, body=body)
+            return _exceptions.InternalServerError(
+                err_msg, response=response, body=body
+            )
         return APIStatusError(err_msg, response=response, body=body)
 
 

--- a/src/llm_api/resources/chat.py
+++ b/src/llm_api/resources/chat.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Dict, Any, List
+from typing import Dict, Any, List  # Standard Library Import
 
-import httpx
+import httpx  # Third-Party Import
 
-from ..types import chat_create_completion_params
-from .._types import Body, Query, Headers, NotGiven, not_given
-from .._utils import maybe_transform, async_maybe_transform
-from .._compat import cached_property
+from .._compat import cached_property  # Local/Project Imports
 from .._resource import SyncAPIResource, AsyncAPIResource
 from .._response import (
     to_raw_response_wrapper,
@@ -18,6 +15,9 @@ from .._response import (
     async_to_streamed_response_wrapper,
 )
 from .._base_client import make_request_options
+from .._types import Body, Query, Headers, NotGiven, not_given
+from .._utils import maybe_transform, async_maybe_transform
+from ..types import chat_create_completion_params
 
 __all__ = ["ChatResource", "AsyncChatResource"]
 

--- a/src/llm_api/resources/chat.py
+++ b/src/llm_api/resources/chat.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Any, List
 
 import httpx
 
@@ -45,7 +45,13 @@ class ChatResource(SyncAPIResource):
     def create_completion(
         self,
         *,
-        body: Dict[str, object],
+        messages: List[Dict[str, Any]],
+        model: str,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        top_k: int,
+        stream: bool,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -81,9 +87,23 @@ class ChatResource(SyncAPIResource):
         """
         return self._post(
             "/chat/completions",
-            body=maybe_transform(body, chat_create_completion_params.ChatCreateCompletionParams),
+            body=maybe_transform(
+                {
+                    "messages": messages,
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    "top_p": top_p,
+                    "top_k": top_k,
+                    "stream": stream,
+                },
+                chat_create_completion_params.ChatCreateCompletionParams,
+            ),
             options=make_request_options(
-                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
             ),
             cast_to=object,
         )
@@ -112,7 +132,13 @@ class AsyncChatResource(AsyncAPIResource):
     async def create_completion(
         self,
         *,
-        body: Dict[str, object],
+        messages: List[Dict[str, Any]],
+        model: str,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        top_k: int,
+        stream: bool,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -148,9 +174,23 @@ class AsyncChatResource(AsyncAPIResource):
         """
         return await self._post(
             "/chat/completions",
-            body=await async_maybe_transform(body, chat_create_completion_params.ChatCreateCompletionParams),
+            body=await async_maybe_transform(
+                {
+                    "messages": messages,
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    "top_p": top_p,
+                    "top_k": top_k,
+                    "stream": stream,
+                },
+                chat_create_completion_params.ChatCreateCompletionParams,
+            ),
             options=make_request_options(
-                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
             ),
             cast_to=object,
         )

--- a/src/llm_api/types/chat_create_completion_params.py
+++ b/src/llm_api/types/chat_create_completion_params.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Dict
-from typing_extensions import Required, TypedDict
+from typing import Dict, Any, List
+from typing_extensions import TypedDict
 
 __all__ = ["ChatCreateCompletionParams"]
 
 
 class ChatCreateCompletionParams(TypedDict, total=False):
-    body: Required[Dict[str, object]]
+    messages: List[Dict[str, Any]]
+    model: str
+    max_tokens: int
+    temperature: float
+    top_p: float
+    top_k: int
+    stream: bool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Chat completion methods (sync and async) now accept explicit parameters: messages, model, max_tokens, temperature, top_p, top_k, and stream instead of a single body dictionary.
  - Completion parameter type now exposes those fields directly rather than a nested body.

- New Features
  - Default API base URL now defaults to http://localhost:8000/openai/v1 when none is provided.

- Style
  - Formatting updates to error messages and exported declarations; no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->